### PR TITLE
listxattr: cast to c_char instead of i8 or u8 -> useful for aarch64

### DIFF
--- a/src/sys/xattr.rs
+++ b/src/sys/xattr.rs
@@ -64,7 +64,7 @@ fn lgetxattr<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
 fn listxattr<P: ?Sized + NixPath>(path: &P, list: &mut [u8]) -> Result<usize> {
     let res = try!(unsafe {
         path.with_nix_path(|cstr| {
-            libc::listxattr(cstr.as_ptr(), list.as_mut_ptr() as *mut i8, list.len())
+            libc::listxattr(cstr.as_ptr(), list.as_mut_ptr() as *mut libc::c_char, list.len())
         })
     });
     Errno::result(res).map(|size| size as usize)
@@ -72,7 +72,7 @@ fn listxattr<P: ?Sized + NixPath>(path: &P, list: &mut [u8]) -> Result<usize> {
 
 #[allow(unused)]
 fn flistxattr(fd: RawFd, list: &mut [u8]) -> Result<usize> {
-    let res = unsafe { libc::flistxattr(fd, list.as_mut_ptr() as *mut i8, list.len()) };
+    let res = unsafe { libc::flistxattr(fd, list.as_mut_ptr() as *mut libc::c_char, list.len()) };
     Errno::result(res).map(|size| size as usize)
 }
 
@@ -80,7 +80,7 @@ fn flistxattr(fd: RawFd, list: &mut [u8]) -> Result<usize> {
 fn llistxattr<P: ?Sized + NixPath>(path: &P, list: &mut [u8]) -> Result<usize> {
     let res = try!(unsafe {
         path.with_nix_path(|cstr| {
-            libc::llistxattr(cstr.as_ptr(), list.as_mut_ptr() as *mut i8, list.len())
+            libc::llistxattr(cstr.as_ptr(), list.as_mut_ptr() as *mut libc::c_char, list.len())
         })
     });
     Errno::result(res).map(|size| size as usize)


### PR DESCRIPTION
I'm trying to use cntr on aarch64 (RockPro64) with NixOS. This fails with:

```
$ nix-shell -p '(import <nixpkgs> { config.allowUnsupportedSystem = true; }).cntr'
...
error[E0308]: mismatched types
  --> /build/cntr-1.2.1-vendor.tar.gz/cntr-nix/src/sys/xattr.rs:63:44
   |
63 |             libc::listxattr(cstr.as_ptr(), list.as_mut_ptr() as *mut i8, list.len())
   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*mut u8`
              found raw pointer `*mut i8`

error[E0308]: mismatched types
  --> /build/cntr-1.2.1-vendor.tar.gz/cntr-nix/src/sys/xattr.rs:70:45
   |
70 |     let res = unsafe { libc::flistxattr(fd, list.as_mut_ptr() as *mut i8, list.len()) };
   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*mut u8`
              found raw pointer `*mut i8`

error[E0308]: mismatched types
  --> /build/cntr-1.2.1-vendor.tar.gz/cntr-nix/src/sys/xattr.rs:77:45
   |
77 |             libc::llistxattr(cstr.as_ptr(), list.as_mut_ptr() as *mut i8, list.len())
   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*mut u8`
              found raw pointer `*mut i8`
```

The documentation says that `listxattr` takes a `c_char` instead of `i8` or `u8`: https://docs.rs/libc/0.2.81/libc/fn.listxattr.html

I have tested my changes on NixOS 20.09 with the package cntr-1.2.1, which uses cntr-nix-0.11.0-pre1. As the code is similar in newer versions, I think the same patch will work. I have *not* tested this. To be honest, I don't really know how to test this - I'm not usually using Rust software (yet).